### PR TITLE
Add bnd processing to create OSGi bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,33 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<configuration>
+					<bnd>
+						<![CDATA[ 
+Export-Package: com.api.jsonata4java.expressions
+					]]>
+					</bnd>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.1.0</version>


### PR DESCRIPTION
In order to use this library in an OSGi environment it needs to be packaged as an OSGi bundle with the necessary fields in the `MANIFEST.MF` file giving the description and version along with the exported Java packages.

Adding the `bnd` plug-in with required configuration adds these in while maintaining the rest of the build.