### PR TITLE
Gitignore IntelliJ files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /Flattenning.trace
 /ObjectArrayRetrieval.trace
 /Study.txt
-/.idea/
+/.idea/*
+!/.idea/workspace.xml
 /JSONata4Java.iml

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /Flattenning.trace
 /ObjectArrayRetrieval.trace
 /Study.txt
+/.idea/
+/JSONata4Java.iml


### PR DESCRIPTION
Just a preference thing. Personally I like putting the IDE exclusions in the repo .gitignore however .git/info/exclude or ~/.gitignore is fine too.