### PR TITLE
Resolve compile issue

### DIFF
--- a/src/main/java/com/api/jsonata4java/expressions/functions/EvalFunction.java
+++ b/src/main/java/com/api/jsonata4java/expressions/functions/EvalFunction.java
@@ -23,7 +23,6 @@
 package com.api.jsonata4java.expressions.functions;
 
 import com.api.jsonata4java.Expression;
-import com.api.jsonata4java.expressions.EvaluateException;
 import com.api.jsonata4java.expressions.EvaluateRuntimeException;
 import com.api.jsonata4java.expressions.ExpressionsVisitor;
 import com.api.jsonata4java.expressions.ParseException;
@@ -84,7 +83,7 @@ public class EvalFunction extends FunctionBase implements Function {
 			try {
 				Expression expr = Expression.jsonata(expression);
 				result = expr.evaluate(context);
-			} catch (EvaluateException | ParseException | IOException e) {
+			} catch (ParseException | IOException e) {
 				throw new EvaluateRuntimeException(ERR_ARG1BADTYPE);
 			}
 		} else {


### PR DESCRIPTION
In my previous PR it looks like I missed one of the places where the unthrown `EvaluateException` was being processed. Now the `throws EvalauteException` has been removed the build fails due to this now redundant processing.

This PR Resolves #170 . 

I couldn't run the build before as I didn't have eclipse at the time. Figured out running in vscode using `mvn install -f "./JSONata4Java/pom.xml" -Dgpg.skip=true`. gpg always seemed to fail so I just skipped.