### PR TITLE
Regex with multiline

### DIFF
--- a/src/main/java/com/api/jsonata4java/expressions/RegularExpression.java
+++ b/src/main/java/com/api/jsonata4java/expressions/RegularExpression.java
@@ -59,17 +59,6 @@ public class RegularExpression {
 		compile();
 	}
 
-	public RegularExpression extend() {
-		if (!(regexPattern.startsWith("^") || regexPattern.startsWith("\\A"))) {
-			regexPattern = ".*" + regexPattern;
-		}
-		if (!(regexPattern.endsWith("$") || regexPattern.endsWith("\\z") || regexPattern.endsWith("\\Z"))) {
-			regexPattern = regexPattern + ".*";
-		}
-		compile();
-		return this;
-	}
-
 	private void compile() {
 		switch (this.type) {
 		case CASEINSENSITIVE:

--- a/src/main/java/com/api/jsonata4java/expressions/functions/ContainsFunction.java
+++ b/src/main/java/com/api/jsonata4java/expressions/functions/ContainsFunction.java
@@ -118,8 +118,8 @@ public class ContainsFunction extends FunctionBase implements Function {
 					result = str.contains(argPattern.textValue()) ? BooleanNode.TRUE : BooleanNode.FALSE;
 				} else if (argPattern instanceof POJONode) {
 					// Match against a regular expression
-					final RegularExpression regex = ((RegularExpression) ((POJONode) argPattern).getPojo()).extend();
-					result = regex.getPattern().matcher(str).matches() ? BooleanNode.TRUE : BooleanNode.FALSE;
+					final RegularExpression regex = ((RegularExpression) ((POJONode) argPattern).getPojo());
+					result = regex.getPattern().matcher(str).find() ? BooleanNode.TRUE : BooleanNode.FALSE;
 				} else {
 					throw new EvaluateRuntimeException(ERR_ARG2BADTYPE);
 				}

--- a/src/test/java/com/api/jsonata4java/test/expressions/ContainsFunctionTests.java
+++ b/src/test/java/com/api/jsonata4java/test/expressions/ContainsFunctionTests.java
@@ -136,7 +136,16 @@ public class ContainsFunctionTests implements Serializable {
 				{ "$contains(\"abra   cadabra\", /^abra\\x20*cadabra$/)", "true", null, },
 				{ "($compute := function($val1, $val2) { $val1 + $val2}; $contains($string($compute(120000 / 3 / 2, 10000)), /30+/))", "true", null },
 				{ "$contains('Hello World', /wo/i)", "true", null },
-				{ "$contains('Hello World Games', /World/m)", "true", null },
+				{ "$contains('Hello World Games\\nHello Europe Games', /World/)", "true", null },
+				{ "$contains('12xyzabc3def', /[0-9]+/)", "true", null },
+				{ "$contains('12xyz\\nabc\\n3def', /[0-9]+/)", "true", null },
+				{ "$contains('12xyz\\nabc\\n3def', /^[0-9]+.*$/)", "false", null },
+				{ "$contains('12xyz\\nabc\\n3def', /^[0-9]+.*$/m)", "true", null },
+				{ "$contains('12xyz\\nabc\\n3def', /[0-9]+/)", "true", null },
+				{ "$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /([0-9]+)/)", "true", null },
+				{ "$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /(^[0-9]+)/)", "true", null },
+				{ "$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/)", "false", null },
+				{ "$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/m)", "true", null },
 		});
 	}
 

--- a/src/test/java/com/api/jsonata4java/test/expressions/FunctionErrorTests.java
+++ b/src/test/java/com/api/jsonata4java/test/expressions/FunctionErrorTests.java
@@ -206,6 +206,8 @@ public class FunctionErrorTests {
 
 	@Test
 	public void containsCaseInsensitively() throws Exception {
+		test("$contains('xyxyABCdefxyxxy', /ab.*ef/)", "false", null, null);
+		test("$contains('xyxyABCdefxyxxy', /ab.*ef/i)", "true", null, null);
 		test("$contains('ABCdef', /^ab.*ef$/)", "false", null, null);
 		test("$contains('ABCdef', /^ab.*ef$/i)", "true", null, null);
 	}
@@ -214,16 +216,21 @@ public class FunctionErrorTests {
 	public void replaceWithMultilinedText() throws Exception {
 		test("$replace('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/, '$1---$2')", "\"1234sjdffjf\\n5678jkfjf\\n9999fg grrs\"", null, null);
 		test("$replace('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/m, '$1---$2')", "\"1234---sjdffjf\\n5678---jkfjf\\n9999---fg grrs\"", null, null);
+		test("$replace('1234sjdffjf\\njkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/m, '$1---$2')", "\"1234---sjdffjf\\njkfjf\\n9999---fg grrs\"", null, null);
 	}
 
 	// while $replace() works out fine (original JSONata like) with "multilined" strings
 	// $contains has problems
 	@Test
 	public void containsWithMultilinedText() throws Exception {
-		// TODO make run: test("$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /([0-9]+)/)", "true", null, null);
-		// TODO make run: test("$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /(^[0-9]+)/)", "true", null, null);
-		// TODO make run: test("$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/)", "false", null, null);
-		// TODO make run
+		test("$contains('12xyzabc3def', /[0-9]+/)", "true", null, null);
+		test("$contains('12xyz\\nabc\\n3def', /[0-9]+/)", "true", null, null);
+		test("$contains('12xyz\\nabc\\n3def', /^[0-9]+.*$/)", "false", null, null);
+		test("$contains('12xyz\\nabc\\n3def', /^[0-9]+.*$/m)", "true", null, null);
+		test("$contains('12xyz\\nabc\\n3def', /[0-9]+/)", "true", null, null);
+		test("$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /([0-9]+)/)", "true", null, null);
+		test("$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /(^[0-9]+)/)", "true", null, null);
+		test("$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/)", "false", null, null);
 		test("$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/m)", "true", null, null);
 	}
 

--- a/src/test/java/com/api/jsonata4java/test/expressions/FunctionErrorTests.java
+++ b/src/test/java/com/api/jsonata4java/test/expressions/FunctionErrorTests.java
@@ -211,6 +211,23 @@ public class FunctionErrorTests {
 	}
 
 	@Test
+	public void replaceWithMultilinedText() throws Exception {
+		test("$replace('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/, '$1---$2')", "\"1234sjdffjf\\n5678jkfjf\\n9999fg grrs\"", null, null);
+		test("$replace('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/m, '$1---$2')", "\"1234---sjdffjf\\n5678---jkfjf\\n9999---fg grrs\"", null, null);
+	}
+
+	// while $replace() works out fine (original JSONata like) with "multilined" strings
+	// $contains has problems
+	@Test
+	public void containsWithMultilinedText() throws Exception {
+		// TODO make run: test("$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /([0-9]+)/)", "true", null, null);
+		// TODO make run: test("$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /(^[0-9]+)/)", "true", null, null);
+		// TODO make run: test("$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/)", "false", null, null);
+		// TODO make run
+		test("$contains('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/m)", "true", null, null);
+	}
+
+	@Test
 	public void splitWithRegex() throws Exception {
 		test("$split('this     is   a simple  test', /\\s+/)", "[ \"this\", \"is\", \"a\", \"simple\", \"test\" ]", null, null);
 	}

--- a/src/test/java/com/api/jsonata4java/test/expressions/MatchFunctionTests.java
+++ b/src/test/java/com/api/jsonata4java/test/expressions/MatchFunctionTests.java
@@ -156,6 +156,20 @@ public class MatchFunctionTests implements Serializable {
 						+ "{\"match\":\"Aabb\",\"index\":4,\"groups\":[\"Aa\",\"bb\"]},"
 						+ "{\"match\":\"aAaB\",\"index\":8,\"groups\":[\"aAa\",\"B\"]}]",
 						null },
+				// $match() seems to work out equally with and with /m
+				// This seems to hold for original JSONata as well as for Java regular expressions
+				{ "$match('ex12am345\\n6ple89', /[0-9]+/)",
+							"[{\"match\":\"12\",\"index\":2,\"groups\":[]},"
+							+ "{\"match\":\"345\",\"index\":6,\"groups\":[]},"
+							+ "{\"match\":\"6\",\"index\":10,\"groups\":[]},"
+							+ "{\"match\":\"89\",\"index\":14,\"groups\":[]}]",
+							null },
+				{ "$match('ex12am345\\n6ple89', /[0-9]+/m)",
+								"[{\"match\":\"12\",\"index\":2,\"groups\":[]},"
+								+ "{\"match\":\"345\",\"index\":6,\"groups\":[]},"
+								+ "{\"match\":\"6\",\"index\":10,\"groups\":[]},"
+								+ "{\"match\":\"89\",\"index\":14,\"groups\":[]}]",
+								null },
 		});
 	}
 

--- a/src/test/java/com/api/jsonata4java/test/expressions/RegularExpressionTest.java
+++ b/src/test/java/com/api/jsonata4java/test/expressions/RegularExpressionTest.java
@@ -44,15 +44,16 @@ public class RegularExpressionTest {
 	}
 
 	@Test
-	public void matches() {
-		assertTrue(new RegularExpression("/^.*$/").getPattern().matcher("asdfgh").matches());
-		assertTrue(new RegularExpression("/^ab.*ef$/").getPattern().matcher("abcdef").matches());
-		assertTrue(new RegularExpression("/c.*f/").getPattern().matcher("abcdefgh").matches());
+	public void find() {
+		assertTrue(new RegularExpression("/^.*$/").getPattern().matcher("asdfgh").find());
+		assertTrue(new RegularExpression("/^ab.*ef$/").getPattern().matcher("abcdef").find());
+		assertTrue(new RegularExpression("/c.*f/").getPattern().matcher("abcdefgh").find());
 	}
 
 	@Test
-	public void matchesCaseInsensitive() {
-		assertFalse(new RegularExpression("/^ab.*ef$/").getPattern().matcher("ABCdef").matches());	
-		assertTrue(new RegularExpression(RegularExpression.Type.CASEINSENSITIVE, "/^ab.*ef$/").getPattern().matcher("ABCdef").matches());		
+	public void findCaseInsensitive() {
+		assertFalse(new RegularExpression("/^ab.*ef$/").getPattern().matcher("ABCdef").find());	
+		assertTrue(new RegularExpression(RegularExpression.Type.CASEINSENSITIVE, "/^ab.*ef$/")
+				.getPattern().matcher("ABCdef").find());		
 	}
 }

--- a/src/test/java/com/api/jsonata4java/test/expressions/ReplaceFunctionTests.java
+++ b/src/test/java/com/api/jsonata4java/test/expressions/ReplaceFunctionTests.java
@@ -205,6 +205,9 @@ public class ReplaceFunctionTests implements Serializable {
 		        { "$replace('a-b---+c--d', '-+', '_', 2)", "\"a-b--_c--d\"", null }, //
 		        { "$replace('fooa123aAafuoAa456aaAfioAaAa789afoo', /a+/i, '--')", "\"foo--123--fuo--456--fio--789--foo\"", null }, //
 		        { "$replace('fooa123aAafuoAa456aaAfioAaAa789afoo', /a+/i, '--', 4)", "\"foo--123--fuo--456--fioAaAa789afoo\"", null }, //
+		        { "$replace('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/, '$1---$2')", "\"1234sjdffjf\\n5678jkfjf\\n9999fg grrs\"", null }, //
+		        { "$replace('1234sjdffjf\\n5678jkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/m, '$1---$2')", "\"1234---sjdffjf\\n5678---jkfjf\\n9999---fg grrs\"", null }, //
+		        { "$replace('1234sjdffjf\\njkfjf\\n9999fg grrs', /^([0-9]+)(.*)$/m, '$1---$2')", "\"1234---sjdffjf\\njkfjf\\n9999---fg grrs\"", null }, //
 		    	// JSNOata test suite group "regex" case012
 		        { "$replace(\"265USD\", /([0-9]+)USD/, \"$$$1\")", "\"$265\"", null }, //
 		    	// JSNOata test suite group "regex" case013

--- a/src/test/java/com/api/jsonata4java/test/expressions/SplitFunctionTests.java
+++ b/src/test/java/com/api/jsonata4java/test/expressions/SplitFunctionTests.java
@@ -138,6 +138,12 @@ public class SplitFunctionTests implements Serializable {
 				{ "$split('this     is   a +simple  test', ' +')", "[\"this     is   a\",\"simple  test\"]", null },
 				{ "$split('thisOOOOOisOOOaOsimpleOOtest', /O+/)", "[ \"this\", \"is\", \"a\", \"simple\", \"test\" ]", null },
 				{ "$split('thisOoOooisOoOaOsimpleOotest', /O+/i)", "[ \"this\", \"is\", \"a\", \"simple\", \"test\" ]", null },
+				// $split() seems to work out equally with and with /m
+				// This seems to hold for original JSONata as well as for Java regular expressions
+				{ "$split('this   is a  simple   test\\nwith a    second     line.', /[\\s]+/)",
+					"[ \"this\", \"is\", \"a\", \"simple\", \"test\", \"with\", \"a\", \"second\", \"line.\" ]", null },
+				{ "$split('this   is a  simple   test\\nwith a    second     line.', /[\\s]+/m)",
+						"[ \"this\", \"is\", \"a\", \"simple\", \"test\", \"with\", \"a\", \"second\", \"line.\" ]", null },
 		});
 	}
 


### PR DESCRIPTION
Here is a small fix for function $contains() when working with regular expressions.

Found out that usage of Java regex matcher function "find()" produces better results than "match()"
(see also https://stackoverflow.com/questions/4450045/difference-between-matches-and-find-in-java-regex)
especially when working with "multilined" strings.
Additionally this way I could simplify the production code.

Functions $replace(), $split(), $match() have now also been testet with "multilined" strings.
They seem to behave like in original JSONata.