### PR TITLE
Fix toMillis() with "picture" with date only.

### DIFF
--- a/src/main/java/com/api/jsonata4java/expressions/utils/DateTimeUtils.java
+++ b/src/main/java/com/api/jsonata4java/expressions/utils/DateTimeUtils.java
@@ -889,7 +889,7 @@ public class DateTimeUtils implements Serializable {
             String timeComps = timeB ? "Phmsf" : "Hmsf";
             String comps = dateComps + timeComps;
 
-            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
 
             boolean startSpecified = false;
             boolean endSpecified = false;

--- a/src/test/java/com/api/jsonata4java/test/expressions/FunctionErrorTests.java
+++ b/src/test/java/com/api/jsonata4java/test/expressions/FunctionErrorTests.java
@@ -37,6 +37,11 @@ import com.api.jsonata4java.expressions.functions.ReplaceFunction;
  */
 public class FunctionErrorTests {
 
+	@Test
+	public void testToMillis_failingInEuropeBetweenMidnightAnd2() throws Exception {
+		test("($toMillis('13:45', '[H]:[m]') ~> $fromMillis() ~> $substringBefore('T')) = $substringBefore($now(), 'T')", "true", null, null);
+	}
+
 	// From JSONata test group "regex"
 
 	// in contrary to JSONata Java does not allow to use capturing group numbers in


### PR DESCRIPTION
Issue #218: toMillis() delivers non UTC date at a certain time period of the day

After having struggled with test class ToMillisFunctionTests failing sometimes I've now found out that one of it fails here in Europe only when I run it between 0:00 and 2:00. The rest of the day it ist green.
The "nasty" test is this one here from line 119:
{ "($toMillis('13:45', '[H]:[m]') ~> $fromMillis() ~> $substringBefore('T')) = $substringBefore($now(), 'T')","true",null},

Example running the test at 01:53 here in Germany:
now() in this case is e.g. 2022-10-15T23:53:42.325Z this is correclty UTC as specified in the JSONata docu
$toMillis('13:45', '[H]:[m]') ~> $fromMillis() is in JSONata4Java 2022-10-16T13:45:00.000Z
This constellation lets the test fail.
In original JSONata however I get 2022-10-15T13:45:00.000Z which would let the test succeed

Having a short debug int the implementation of toMillis() I see the the underlying function DateTimeUtils.parseDateTime() uses LocalDateTime now = LocalDateTime.now(); (line 892) which is the Central European Time in my case.
We can easily fix this one by replacing the lin above with:
LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);