### PR TITLE
Update Jackson version and revert Java 11 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.14.0-rc2</version>
+			<version>2.14.0</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.fasterxml.woodstox/woodstox-core -->
 		<dependency>
@@ -114,7 +114,7 @@
 	    <dependency>
 	      <groupId>com.fasterxml.jackson.dataformat</groupId>
 	      <artifactId>jackson-dataformat-xml</artifactId>
-	      <version>2.14.0-rc2</version>
+	      <version>2.14.0</version>
 	    </dependency>
 		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-text -->
 		<dependency>
@@ -208,7 +208,7 @@
 					</execution>
 				</executions>
 				<configuration>
-				    <source>11</source>
+				    <source>1.8</source>
 					<additionalOptions>
 						<additionalOption>-Xdoclint:none</additionalOption>
 					</additionalOptions>
@@ -218,8 +218,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<additionalClasspathElements>
 					</additionalClasspathElements>
 				</configuration>


### PR DESCRIPTION
For inclusion in our product (and to pick up the commons-text security fix) we need the Jackson dependencies to be a GA version and to be able to run at Java 8.
