### PR TITLE
Add JavaDoc to describe the difference between no match and a JSON null

### DIFF
--- a/src/main/java/com/api/jsonata4java/Expression.java
+++ b/src/main/java/com/api/jsonata4java/Expression.java
@@ -186,7 +186,8 @@ public class Expression implements Serializable {
      *                    JSON object specifying the content used to evaluate the
      *                    expression
      * @return the result from executing the Expression's parsed expression and
-     *         variable assignments or registered functions
+     *         variable assignments or registered functions. A null will be returned if 
+     *         no match is found (note a JSON null will result in a JsonNode of type NullNode).
      * @throws ParseException
      */
     public JsonNode evaluate(JsonNode rootContext) throws ParseException {
@@ -217,7 +218,8 @@ public class Expression implements Serializable {
      *                    function declarations
      * @return the result from executing the Expression's parsed expression and
      *         variable assignments or registered functions specified in the list of
-     *         bindings
+     *         bindings. A null will be returned if no match is found (note a JSON null will 
+ 	 *         result in a JsonNode of type NullNode).
      * @throws ParseException
      */
     public JsonNode evaluate(JsonNode rootContext, List<Binding> bindings) throws ParseException {

--- a/src/main/java/com/api/jsonata4java/expressions/Expressions.java
+++ b/src/main/java/com/api/jsonata4java/expressions/Expressions.java
@@ -140,7 +140,9 @@ public class Expressions implements Serializable {
     *                    an exception is thrown. Must be positive number or exception is thrown.
     * @param maxDepth the maximum call stack depth allowed before an exception is thrown. Must 
     *                    be a positive number or an exception is thrown.
-    * @return the JsonNode resulting from the expression evaluation against the rootContext
+    * @return the JsonNode resulting from the expression evaluation against the rootContext. 
+    *         A null will be returned if no match is found (note a JSON null will result 
+    *         in a JsonNode of type NullNode).
     * @throws EvaluateException If the given device event is invalid.
     */
     public JsonNode evaluate(JsonNode rootContext, long timeoutMS, int maxDepth) throws EvaluateException {
@@ -179,7 +181,9 @@ public class Expressions implements Serializable {
      * @param rootContext bound to root context ($$ and paths that don't start with
      *                    $event, $state or $instance) when evaluating expressions.
      *                    May be null.
-     * @return the JsonNode resulting from the expression evaluation against the rootContext
+     * @return the JsonNode resulting from the expression evaluation against the rootContext. 
+     *         A null will be returned if no match is found (note a JSON null will result 
+     *         in a JsonNode of type NullNode).
      * @throws EvaluateException If the given device event is invalid.
      */
     public JsonNode evaluate(JsonNode rootContext) throws EvaluateException {


### PR DESCRIPTION
It is important to be able to distinguish between a no match style result and a null JSON value being returned. JSONata4Java does this by using the type null type for no match and returning a JsonNode which is of type NullNode when a null JSON value is returned.

This PR document this in the @return JavaDoc for evaluate functions.