### PR TITLE
Fixed orderby for boolean and numeric sortfields

### DIFF
--- a/src/main/java/com/api/jsonata4java/expressions/OrderByOperator.java
+++ b/src/main/java/com/api/jsonata4java/expressions/OrderByOperator.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.databind.node.NumericNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
 
 public class OrderByOperator {
 
@@ -35,14 +37,29 @@ public class OrderByOperator {
                 for (final OrderByField sortField : sortFields) {
                     JsonNode n1 = o1.get(sortField.name);
                     JsonNode n2 = o2.get(sortField.name);
-                    if (n1 != null && n1 instanceof TextNode
-                        && n2 != null && n2 instanceof TextNode) {
-                        final int comp = ((TextNode) n1).asText().compareTo(((TextNode) n2).asText());
-                        if (comp != 0) {
-                            return sortField.order == OrderByOrder.DESC ? comp * (-1) : comp;
+                    if (n1 != null && n2 != null) {
+                        if (n1 instanceof TextNode && n2 instanceof TextNode) {
+                            final int comp = ((TextNode) n1).asText().compareTo(((TextNode) n2).asText());
+                            if (comp != 0) {
+                                return sortField.order == OrderByOrder.DESC ? comp * -1 : comp;
+                            }
                         }
-                    }
-                }
+                        if (n1 instanceof NumericNode && n2 instanceof NumericNode) {
+                            final int comp = (int) Double.compare(((NumericNode) n1).asDouble(), ((NumericNode) n2).asDouble());
+                            if (comp != 0) {
+                                return sortField.order == OrderByOrder.DESC ? comp * -1 : comp;
+                            }
+
+                        }
+                        if (n1 instanceof BooleanNode && n2 instanceof BooleanNode) {
+                            final int comp = Boolean.compare(((BooleanNode) n1).asBoolean(), ((BooleanNode) n2).asBoolean());
+                            if (comp != 0) {
+                                return sortField.order == OrderByOrder.DESC ? comp * -1 : comp;
+                            }
+
+                         }
+                     }
+				}
                 return 0;
             }
         });

--- a/src/test/java/com/api/jsonata4java/test/expressions/OpOrderByTest.java
+++ b/src/test/java/com/api/jsonata4java/test/expressions/OpOrderByTest.java
@@ -61,4 +61,11 @@ public class OpOrderByTest {
             "[{\"id\":\"1\",\"content\":\"1\"},{\"id\":\"2\",\"content\":\"1\"},{\"id\":\"2\",\"content\":\"2\"}]", null,
             "[{\"id\":\"1\",\"content\":\"1\"},{\"id\":\"2\",\"content\":\"1\"},{\"id\":\"2\",\"content\":\"2\"}]");
     }
+	
+    @Test
+    public void testOrderedNumeric() throws Exception {
+        test("$^(id, content)",
+                "[{\"id\":1,\"content\":\"1\"},{\"id\":2,\"content\":\"1\"},{\"id\":2,\"content\":\"2\"}]", null,
+                "[{\"id\":2,\"content\":\"2\"},{\"id\":2,\"content\":\"1\"},{\"id\":1,\"content\":\"1\"}]");
+     }
 }


### PR DESCRIPTION
This fixes ordering by boolean and numeric fields.

Fixes https://github.com/IBM/JSONata4Java/issues/271