### PR TITLE
Add upper/lower presentation format for am/pm in fromMillis

### DIFF
--- a/src/main/java/com/api/jsonata4java/expressions/utils/DateTimeUtils.java
+++ b/src/main/java/com/api/jsonata4java/expressions/utils/DateTimeUtils.java
@@ -774,6 +774,13 @@ public class DateTimeUtils implements Serializable {
             if (offset == 0 && markerSpec.presentation2 != null && markerSpec.presentation2 == 't') {
                 componentValue = "Z";
             }
+        } else if (markerSpec.component == 'P') {
+            // §9.8.4.7 Formatting Other Components
+            // Formatting P for am/pm
+            // getDateTimeFragment() always returns am/pm lower case so check for UPPER here
+            if (markerSpec.names == tcase.UPPER) {
+                componentValue = componentValue.toUpperCase();
+            }
         }
         return componentValue;
     }

--- a/src/test/java/com/api/jsonata4java/expressions/FromMillisFunctionTests.java
+++ b/src/test/java/com/api/jsonata4java/expressions/FromMillisFunctionTests.java
@@ -296,6 +296,12 @@ public class FromMillisFunctionTests implements Serializable {
                         // { "$fromMillis(1483272000000, \"Week: [w] of [xNn]\")","\"Week: 5 of December\"",null},
                         // { "$fromMillis(1533038400000, \"Week: [w] of [xNn]\")","\"Week: 1 of August\"",null},
                         // { "$fromMillis(1419940800000, \"Week: [w] of [xNn]\")","\"Week: 1 of January\"",null},
+            {
+            	"$fromMillis(1521801216617, \"[F], [D]/[M]/[Y] [h]:[m]:[s] [PN]\")", "\"friday, 23/3/2018 10:33:36 AM\"", null
+            },
+            {
+            	"$fromMillis(1521801216617, \"[F], [D]/[M]/[Y] [h]:[m]:[s] [Pn]\")", "\"friday, 23/3/2018 10:33:36 am\"", null
+            },
         });
     }
 


### PR DESCRIPTION
Fixes #276

Fix is based on the original JSONata fix, (https://github.com/jsonata-js/jsonata/pull/644) basically just removed the extra = from === as the code is consistent between the JS and Java versions.

Updates [$fromMillis() function](https://docs.jsonata.org/date-time-functions#frommillis) to support am/pm PN presentation format to output AM/PM and adds test cases for PN and Pn (existing test case for default presentation covers just P).