### PR TITLE
#292 Some $reduce(..., $append) expressions work very slow

### DIFF
--- a/src/main/java/com/api/jsonata4java/expressions/functions/AppendFunction.java
+++ b/src/main/java/com/api/jsonata4java/expressions/functions/AppendFunction.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 
-public class AppendFunction extends FunctionBase {
+public class AppendFunction extends FunctionBase implements NoContextFunction {
 
     public static String ERR_BAD_CONTEXT = String.format(Constants.ERR_MSG_BAD_CONTEXT, Constants.FUNCTION_APPEND);
     public static String ERR_ARG1BADTYPE = String.format(Constants.ERR_MSG_ARG1_BAD_TYPE, Constants.FUNCTION_APPEND);
@@ -96,6 +96,16 @@ public class AppendFunction extends FunctionBase {
         }
 
         return result;
+    }
+
+    @Override
+    public JsonNode invoke(JsonNode... elements) {
+        ArrayNode a = ArrayUtils.ensureArray(elements[0]);
+        ArrayNode b = ArrayUtils.ensureArray(elements[1]);
+
+        a.addAll(b);
+
+        return a;
     }
 
     @Override

--- a/src/main/java/com/api/jsonata4java/expressions/functions/NoContextFunction.java
+++ b/src/main/java/com/api/jsonata4java/expressions/functions/NoContextFunction.java
@@ -1,0 +1,11 @@
+package com.api.jsonata4java.expressions.functions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Optimized version of {@link FunctionBase} where parameters don't have to be converted
+ * from {@link JsonNode} to call context
+ */
+public interface NoContextFunction {
+    JsonNode invoke(JsonNode... elements);
+}

--- a/src/main/java/com/api/jsonata4java/expressions/utils/FunctionUtils.java
+++ b/src/main/java/com/api/jsonata4java/expressions/utils/FunctionUtils.java
@@ -26,6 +26,8 @@ import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
+
+import com.api.jsonata4java.expressions.functions.NoContextFunction;
 import org.antlr.v4.runtime.CommonToken;
 import org.antlr.v4.runtime.CommonTokenFactory;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -666,6 +668,9 @@ public class FunctionUtils implements Serializable {
      */
     public static JsonNode processVariablesCallFunction(ExpressionsVisitor exprVisitor, FunctionBase function,
         TerminalNode varid, Function_callContext ctx, JsonNode... elements) {
+        if (function instanceof NoContextFunction)
+            return ((NoContextFunction) function).invoke(elements);
+
         ExprListContext elc = new ExprListContext(ctx.getParent(), ctx.invokingState);
         ExprValuesContext evc = new ExprValuesContext(ctx.getParent(), ctx.invokingState);
         evc.addAnyChild(new TerminalNodeImpl(CommonTokenFactory.DEFAULT.create(MappingExpressionParser.T__1, "(")));


### PR DESCRIPTION
Fixed using a special function interface where JsonNode parameters don't have to be converted to context and back after