### PR TITLE
Fix: Picture string with ordinal not parsed correctly

### DIFF
--- a/src/main/java/com/api/jsonata4java/expressions/utils/DateTimeUtils.java
+++ b/src/main/java/com/api/jsonata4java/expressions/utils/DateTimeUtils.java
@@ -636,7 +636,7 @@ public class DateTimeUtils implements Serializable {
                     }
                 } else if ("YMDdFWwXxHhmsf".indexOf(def.component) != -1) {
                     String integerPattern = def.presentation1;
-                    if (def.presentation2 == null) {
+                    if (def.presentation2 != null) {
                         integerPattern += ";" + def.presentation2;
                     }
                     def.integerFormat = analyseIntegerPicture(integerPattern);


### PR DESCRIPTION
Fix for #310 

---
Expression:

$toMillis('2018th', '[Y0001;o]')

Expected output

1514764800000

Actual output

index out of bounds exception