### PR TITLE
Backport: fix varargs (i.e. <n+:n>) signature validation

### DIFF
--- a/src/main/java/com/api/jsonata4java/Signature.java
+++ b/src/main/java/com/api/jsonata4java/Signature.java
@@ -383,6 +383,7 @@ public class Signature implements Serializable {
                             validatedArgs.add(arg);
                             argIndex++;
                         } else {
+                            arg = expressionVisitor.visit(args.expr(argIndex));
                             validatedArgs.add(arg);
                             argIndex++;
                         }


### PR DESCRIPTION
Using <n+:n> signature, validate will return the first arg n times. As we're based on this impl the fix should be backported

Original fix here:
https://github.com/dashjoin/jsonata-java/commit/3849b71066908de22e70fa076ff21e19ee5a11d6

Test case:
https://github.com/dashjoin/jsonata-java/commit/abf12e92c1155ea092b147278b4d8fcb3bcc42ad