### PR TITLE
use Temurin JDK in GitHub Actions

### DIFF
--- a/.github/workflows/mvntest.yml
+++ b/.github/workflows/mvntest.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify


### PR DESCRIPTION

- AdoptOpenJDK is obsolete
- use Temurin JDK

